### PR TITLE
feat : 선착순 할인 쿠폰 제공 이벤트 초기 구현

### DIFF
--- a/api/src/main/java/com/example/api/domain/Coupon.java
+++ b/api/src/main/java/com/example/api/domain/Coupon.java
@@ -1,0 +1,25 @@
+package com.example.api.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    public Coupon(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/api/src/main/java/com/example/api/repository/CouponRepository.java
+++ b/api/src/main/java/com/example/api/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package com.example.api.repository;
+
+import com.example.api.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon , Long> {
+}

--- a/api/src/main/java/com/example/api/service/ApplyService.java
+++ b/api/src/main/java/com/example/api/service/ApplyService.java
@@ -1,0 +1,23 @@
+package com.example.api.service;
+
+import com.example.api.domain.Coupon;
+import com.example.api.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApplyService {
+
+    private final CouponRepository couponRepository;
+
+    public void apply(Long userId){
+        long count = couponRepository.count();
+
+        if(count > 100){
+            return;
+        }
+
+        couponRepository.save(new Coupon(userId));
+    }
+}

--- a/api/src/test/java/com/example/api/service/ApplyServiceTest.java
+++ b/api/src/test/java/com/example/api/service/ApplyServiceTest.java
@@ -1,0 +1,61 @@
+package com.example.api.service;
+
+import com.example.api.repository.CouponRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ApplyServiceTest {
+
+    @Autowired
+    private ApplyService applyService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Test
+    public void 단일요청쿠폰발급() {
+        applyService.apply(1L);
+
+        long count = couponRepository.count();
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    public void 다중요청쿠폰발급() throws InterruptedException {
+        int threadCount = 1000;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(30);
+
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        //모든 요청이 끝나야함을 기다려야 함
+
+
+        for (int i = 0; i < threadCount; i++) {
+            long userId = i;
+            executorService.submit(() -> {
+                try {
+                    applyService.apply(userId);
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+
+        countDownLatch.await();
+
+        long count = couponRepository.count();
+
+        assertThat(count).isEqualTo(100);
+
+    }
+}


### PR DESCRIPTION
### 요구사항

- 이벤트: 선착순 100명에게 할인 쿠폰 제공
- 조건:
  1. 선착순 100명에게만 쿠폰 제공
  2. 101개 이상 쿠폰 지급 금지
  3. 순간적으로 몰리는 트래픽을 버틸 수 있어야 함

### 변경 내용

1. **이벤트 초기 구현 추가** 🚀:
   - 할인 쿠폰을 선착순 100명에게 제공하는 이벤트를 위한 초기 구현 추가

2. **다중 요청 동시성 문제 발생** 🚧:
   - 다중 요청 시 동시성 문제로 인해 쓰레드 간 레이스 컨디션이 발생함

<img width="356" alt="image" src="https://github.com/seongHyun-Min/coupon-system-kafka/assets/112048126/35bb010d-7bca-4f8f-bb70-71b1cfa695f9">

3. **현재 상태** ⚠️:
   - 초기 구현으로, 다중 요청 시 동시성 문제를 고려하지 않은 상태

### 다음 단계 계획

- **동시성 문제 해결을 위해 레디스를 사용하여 데이터 동기화 구현** 🛡