### PR TITLE
feat: Redis를 활용하여 쿠폰 데이터 동기화 구현 및 동시성 문제 해결

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -22,6 +22,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/api/src/main/java/com/example/api/repository/CouponCountRepository.java
+++ b/api/src/main/java/com/example/api/repository/CouponCountRepository.java
@@ -1,0 +1,18 @@
+package com.example.api.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponCountRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public Long increment(){
+        return redisTemplate
+                .opsForValue()
+                .increment("coupon_count");
+    }
+}

--- a/api/src/main/java/com/example/api/service/ApplyService.java
+++ b/api/src/main/java/com/example/api/service/ApplyService.java
@@ -1,6 +1,7 @@
 package com.example.api.service;
 
 import com.example.api.domain.Coupon;
+import com.example.api.repository.CouponCountRepository;
 import com.example.api.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,8 +12,10 @@ public class ApplyService {
 
     private final CouponRepository couponRepository;
 
+    private final CouponCountRepository couponCountRepository;
+
     public void apply(Long userId){
-        long count = couponRepository.count();
+        Long count = couponCountRepository.increment();
 
         if(count > 100){
             return;


### PR DESCRIPTION
### 요구사항

- 공유하는 값에 동시 연산을 하게 되면 동시성 문제가 발생하여 의도치 못한 값을 얻게 되어 버그를 유발할 수 있다.
- 물론 트래픽이 적을 경우도 문제가 발생하지만 특히 동시에 여러 연산이 자주 일어나는 대규모 시스템에선 문제가 발생할 가능성이 크다.

### 변경 내용

**동시성 문제 해결을 위해 레디스를 사용하여 데이터 동기화 구현** 🛡

  - 락을 활용하여 구현한다면 발급된 쿠폰 개수를 가져오는 것부터 쿠폰을 생성하는 과정까지 락을 걸어야합니다.

   - 그렇게 된다면 락을 거는 구간이 길어져서 성능이 떨어지는 현상이 발생하게 된다.

   - 이 프로젝트의 핵심 키는 쿠폰 개수
   - 발급된 쿠폰의 개수를 제어하기 위해 incr 명령어를 사용한다.

   -  레디스로 Atomic한 연산을 보장할 수 있게하여 안전한 어플리케이션을 구현

   -  INCR 명령어는 여러 서버가 동시에 명령을 날려도 synchronized 키워드를 쓴 것 처럼 명령어가 묶여서 실행되어 Atomic이 보장됨
    
   -  분산락을 건다는 것은 병목 지점을 만드는 것으로 락을 걸지 않을 방법이 있고 해결할수 있는 방법이 있다면 사용!!!

- **Redis를 활용한 쿠폰 개수 제어** 🚀

   Redis의 `INCR` 명령어를 활용하여 쿠폰의 발급 개수를 안전하게 증가시키고, 동시에 발생하는 요청을 순차적으로 처리
 이를 통해 여러 클라이언트가 동시에 쿠폰을 발급하는 시나리오에서도 데이터의 일관성을 유지


<img width="371" alt="image" src="https://github.com/seongHyun-Min/coupon-system-kafka/assets/112048126/4682b21d-a53e-4e5a-a624-bd6e61ef2d6f">


### 다음 단계 계획

- **발급하는 쿠폰의 개수가 많아지면 많아질수록 RDB에 부하**  🚧
- **사용하는 RDB가 쿠폰 뿐만 아니라 다양한 곳에서 사양하고 있다면 서비스 장애** 🛡
- **카프카를 사용하여 위 문제를 해결** 🛡